### PR TITLE
Move CHANGELOG.md during publish process

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Upload Thunderstore Package'
+name: 'Upload Thunderstore Package TEST'
 description: 'Formats and uploads a Thunderstore package'
 author: 'AnActualEmerald'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Upload Thunderstore Package TEST'
+name: 'Upload Thunderstore Package'
 description: 'Formats and uploads a Thunderstore package'
 author: 'AnActualEmerald'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,8 @@ inputs:
     description: 'URL of the mod icon'
   readme:
     description: 'URL of the mod README'
+  changelog:
+    description: 'URL of the mod CHANGELOG'
   description:
     description: 'Description of the mod'
     required: true
@@ -61,6 +63,7 @@ runs:
     TS_DESC: ${{ inputs.description }}
     TS_ICON: ${{ inputs.icon }}
     TS_README: ${{ inputs.readme }}
+    TS_CHANGELOG: ${{ inputs.changelog }}
     TS_PATH: ${{ inputs.path }}
     TS_DEV: ${{ inputs.dev }}
     TS_WRAP: ${{ inputs.wrap }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,9 @@ function setup() {
   if [ -e "/dist/CHANGELOG.md" ]; then
     echo "Move CHANGELOG"
     mv "/dist/CHANGELOG.md" "/"
+  elif [ -n "$TS_CHANGELOG" ]; then
+    echo "Download CHANGELOG from $TS_CHANGELOG"
+    wget -O "/CHANGELOG.md" "$TS_CHANGELOG"
   fi
 
   echo "::endgroup::"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,10 @@ function setup() {
     wget -O "/icon.png" "$TS_ICON"
   fi
 
+  if [ -e "/dist/CHANGELOG.md" ]; then
+    echo "Move CHANGELOG"
+    mv "/dist/CHANGELOG.md" "/"
+  fi
 
   echo "::endgroup::"
 


### PR DESCRIPTION
Prevents CHANGELOG.md from getting ignored during the moving process and staying inside the mod folder:

![image](https://github.com/user-attachments/assets/a397788d-3012-4adc-b6c2-4d58ca1838d7)
![image](https://github.com/user-attachments/assets/daf583bf-52ca-4831-b53a-7790136340f7)

Not sure if downloading the changelog is entirely necessary since TS doesn't use it anyway, but i still kept it just so its consistent with icon.png and README